### PR TITLE
In some case, currentInterfaceName can be null. Take that into account

### DIFF
--- a/checkiid.py
+++ b/checkiid.py
@@ -734,7 +734,7 @@ def parsePatch(aInputPatch, aRootPath):
 
     # if line is change to an interface and not a comment, a constant expr, or
     # an IID removal line:
-    if binaryCompat or (not currentInterfaceWasRenamed and not descr and not iidRemoval and not cmt and not constEx and change and currentInterfaceName):
+    if (binaryCompat or (not currentInterfaceWasRenamed and not descr and not iidRemoval and not cmt and not constEx and change)) and currentInterfaceName:
 
       gPrinter.debug("Line number " + str(lineNo) + " with change to interface '" + str(currentInterfaceName) + "' meets qualifications for needing an IID change.")
       gPrinter.debug("binaryCompat: " + str(binaryCompat))


### PR DESCRIPTION
Without this PR, checkiid is failing with 

```
WARNING: 'nsIDOMMobileMessageManager.idl' was not found in local repository. Are you sure your repository is at the correct revision?
Traceback (most recent call last):
  File "../checkiid/checkiid.py", line 934, in <module>
    runMain()
  File "../checkiid/checkiid.py", line 928, in runMain
    main(rootPath, patchFile)
  File "../checkiid/checkiid.py", line 854, in main
    interfaceFilename = interfaceNameIDLMap[interface]
KeyError: None
```

on this patch:

```
diff --git a/dom/mobilemessage/interfaces/nsIDOMMobileMessageManager.idl b/dom/mobilemessage/interfaces/nsIDOMMobileMessageManager.idl
--- a/dom/mobilemessage/interfaces/nsIDOMMobileMessageManager.idl
+++ b/dom/mobilemessage/interfaces/nsIDOMMobileMessageManager.idl
@@ -73,9 +73,10 @@ interface nsIDOMMozMobileMessageManager 
   [implicit_jscontext] attribute jsval onretrieving;
   [implicit_jscontext] attribute jsval onsending;
   [implicit_jscontext] attribute jsval onsent;
   [implicit_jscontext] attribute jsval onfailed;
   [implicit_jscontext] attribute jsval ondeliverysuccess;
   [implicit_jscontext] attribute jsval ondeliveryerror;
   [implicit_jscontext] attribute jsval onreadsuccess;
   [implicit_jscontext] attribute jsval onreaderror;
+  [implicit_jscontext] attribute jsval ondeleted;
 };
```
